### PR TITLE
Visual Consistency with Node-RED Editor

### DIFF
--- a/flowviewer.css
+++ b/flowviewer.css
@@ -3,6 +3,17 @@ body {
     background-color: #fefcfc
 }
 
+.node {
+    fill-opacity: 1;
+    stroke-width: 1px;
+}
+
+.link {
+    stroke: #999;
+    stroke-width: 3;
+    fill: none;
+}
+
 .group-text-label {
     font-family: Helvetica Neue, Arial, Helvetica, sans-serif;
 	font-size: 14px;

--- a/flowviewer.js
+++ b/flowviewer.js
@@ -1490,9 +1490,7 @@ function renderFlow(flowId, flowdata, svgjQueryObj, renderOpts = {
                         rx: 5,
                         ry: 5,
                         fill: obj.color || clr.fill,
-                        "fill-opacity": 1,
-                        "stroke-width": 2,
-                        class: (" node-" + obj.id)
+                        class: "node " + (" node-" + obj.id)
                     }));
 
                     $(grpObj).attr("transform", "translate(" + (obj.x - dimensions.width/2) + "," + (obj.y - dimensions.height/2) + ")");
@@ -1547,7 +1545,7 @@ function renderFlow(flowId, flowdata, svgjQueryObj, renderOpts = {
 
                     var grpText = document.createElementNS("http://www.w3.org/2000/svg", 'g');
                     grpText.setAttributeNS(null, "id", grpTextId);
-                    grpText.setAttributeNS(null, "transform", "translate(38," + (textLabels.lines.length > 1 ? "18" : "16") + ")");
+                    grpText.setAttributeNS(null, "transform", "translate(38," + (textLabels.lines.length > 1 ? 16 : 14) + ")");
 
                     var ypos = 0;
                     textLabels.lines.forEach( function(lne){
@@ -1567,8 +1565,8 @@ function renderFlow(flowId, flowdata, svgjQueryObj, renderOpts = {
                     $(grpObj).append(grpText);
 
                     var txtBBox    = document.getElementById(grpTextId).getBBox();
-                    var txtWidth   = txtBBox.width + 45;
-                    var txtHeight  = txtBBox.height + 16;
+                    var txtWidth   = txtBBox.width + 60;
+                    var txtHeight  = txtBBox.height + 13.5;
                     var rectWidth  = (dimensions.width > txtWidth ? dimensions.width : txtWidth);
                     var rectHeight = (dimensions.height > txtHeight ? dimensions.height : txtHeight);
 
@@ -1580,7 +1578,7 @@ function renderFlow(flowId, flowdata, svgjQueryObj, renderOpts = {
                         /* move the text block into the middle */
                         if ( rectHeight > txtHeight ) {
                             var offsetHeight = ( rectHeight - txtHeight) / 2;
-                            grpText.setAttributeNS(null, "transform", "translate(38," + ( (textLabels.lines.length > 1 ? 19 : 17) + offsetHeight) + ")");
+                            grpText.setAttributeNS(null, "transform", "translate(38," + ( (textLabels.lines.length > 1 ? 18 : 16) + offsetHeight) + ")");
                         }
                     }
                     
@@ -1589,11 +1587,9 @@ function renderFlow(flowId, flowdata, svgjQueryObj, renderOpts = {
                         rx: 5,
                         ry: 5,
                         fill: obj.color || subflowObj.color || clr.fill,
-                        "fill-opacity": 1,
                         width: rectWidth,
-                        height: rectHeight, 
-                        "stroke-width": 2,
-                        class: (" node-" + obj.id)
+                        height: rectHeight,
+                        class: "node " + (" node-" + obj.id)
                     }));
 
                     $(grpObj).append(getNode('path', {
@@ -1845,10 +1841,7 @@ function renderFlow(flowId, flowdata, svgjQueryObj, renderOpts = {
 
                 $(svgObj).append(getNode('path', {
                     d: generateLinkPath(startX, startY, endX, endY, 1),
-                    stroke: 'grey',
-                    "stroke-width": 4,
-                    "fill": 'transparent',
-                    class: (otherNode.d ? "link-disabled" : "") + (" link-from-" + sfObj.id + "-to-" + otherNode.id)
+                    class: "link " + (otherNode.d ? "link-disabled" : "") + (" link-from-" + sfObj.id + "-to-" + otherNode.id)
                 }));
             }
         }
@@ -1868,10 +1861,7 @@ function renderFlow(flowId, flowdata, svgjQueryObj, renderOpts = {
 
                 $(svgObj).append(getNode('path', {
                     d: generateLinkPath(startX, startY, endX, endY, 1),
-                    stroke: 'grey',
-                    "stroke-width": 4,
-                    "fill": 'transparent',
-                    class: (otherNode.d ? "link-disabled" : "") + (" link-from-" + sfObj.id + "-to-" + otherNode.id)
+                    class: "link " + (otherNode.d ? "link-disabled" : "") + (" link-from-" + sfObj.id + "-to-" + otherNode.id)
                 }));
             }
         }
@@ -1897,10 +1887,7 @@ function renderFlow(flowId, flowdata, svgjQueryObj, renderOpts = {
 
                     $(svgObj).append(getNode('path', {
                         d: generateLinkPath(startX, startY, endX, endY, 1),
-                        stroke: 'grey',
-                        "stroke-width": 4,
-                        "fill": 'transparent',
-                        class: (otherNode.d || nde.d ? "link-disabled" : "") + (" link-from-" + nde.id + "-to-" + otherNode.id)
+                        class: "link " + (otherNode.d || nde.d ? "link-disabled" : "") + (" link-from-" + nde.id + "-to-" + otherNode.id)
                     }));
                 }
             });
@@ -1923,10 +1910,8 @@ function renderFlow(flowId, flowdata, svgjQueryObj, renderOpts = {
                     $(svgObj).append(getNode('path', {
                         d: generateLinkPath(startX, startY, endX, endY, 1),
                         stroke: 'rgb(170, 170, 170)',
-                        "stroke-width": 2,
                         "stroke-dasharray": "25,4",
-                        "fill": 'transparent',
-                        class: (otherNode.d || nde.d ? "link-disabled" : "") + (" link-from-" + nde.id + "-to-" + otherNode.id)
+                        class: "link " + (otherNode.d || nde.d ? "link-disabled" : "") + (" link-from-" + nde.id + "-to-" + otherNode.id)
                     }));
 
                     $(svgObj).append(getNode('circle', {

--- a/flowviewer.js
+++ b/flowviewer.js
@@ -1198,6 +1198,18 @@ function renderFlow(flowId, flowdata, svgjQueryObj, renderOpts = {
     var nodeIdsThatReceiveInput = {};
     var svgObj = undefined;
 
+    const PORT_WIDTH = 10;
+
+    const portDimensions = {
+        width: PORT_WIDTH,
+        height: PORT_WIDTH
+    }
+
+    const portRadius = {
+        rx: 3,
+        ry: 3
+    }
+    
     svgObj = $(svgjQueryObj.find('.flowGridlines')[0]);
 
     if ( renderOpts["gridlines"] ) {
@@ -1279,7 +1291,9 @@ function renderFlow(flowId, flowdata, svgjQueryObj, renderOpts = {
     flowdata.forEach(function (obj) {
         if (obj.z == flowId || obj.id == flowId /* this is a subflow or tab */) {
 
+            // get node dimensions
             var dimensions = widthHeightByType[obj.type] || widthHeightByType["_default"];
+            // get node color
             var clr = clrByType[obj.type] || clrByType["_default"];
 
             switch (obj.type) {
@@ -1325,15 +1339,11 @@ function renderFlow(flowId, flowdata, svgjQueryObj, renderOpts = {
                         inObj.bbox.x = inObj.x - dimensions.width / 2
                         inObj.bbox.y = inObj.y - dimensions.height / 2
 
-                        var transAndPath = {
-                            transform: "translate(15,-5)",
-                            d: "M 0.5,9.5 9.5,9.5 9.5,0.5 0.5,0.5 Z",
-                        }
-
                         /* add output decoration after computing the bounding box - the decoration extends the bounding box */
-                        $(grpObj).append(getNode('path', {
+                        $(grpObj).append(getNode('rect', {
                             ...clr,
-                            ...transAndPath,
+                            ...portDimensions,
+                            ...portRadius,
                             class: "output-deco",
                             "stroke-linecap": "round",
                             "stroke-linejoin": "round",
@@ -1370,18 +1380,16 @@ function renderFlow(flowId, flowdata, svgjQueryObj, renderOpts = {
                         outObj.bbox.x = outObj.x - dimensions.width / 2
                         outObj.bbox.y = outObj.y - dimensions.height / 2
 
-                        var transAndPath = {
-                            transform: "translate(-25,-5)",
-                            d: "M 0.5,9.5 9.5,9.5 9.5,0.5 0.5,0.5 Z",
-                        }
-
                         /* add output decoration after computing the bounding box - the decoration extends the bounding box */
-                        $(grpObj).append(getNode('path', {
+                        $(grpObj).append(getNode('rect', {
                             ...clr,
-                            ...transAndPath,
+                            ...portDimensions,
+                            ...portRadius,
                             class: "input-deco",
                             "stroke-linecap": "round",
                             "stroke-linejoin": "round",
+                            rx: 3,
+                            ry: 3,
                         }));
 
                         /* text that goes "output\n(idx+1)\n" i.e. two lines */
@@ -1424,15 +1432,11 @@ function renderFlow(flowId, flowdata, svgjQueryObj, renderOpts = {
                         outObj.bbox.x = outObj.x - dimensions.width / 2
                         outObj.bbox.y = outObj.y - dimensions.height / 2
 
-                        var transAndPath = {
-                            transform: "translate(-25,-5)",
-                            d: "M 0.5,9.5 9.5,9.5 9.5,0.5 0.5,0.5 Z",
-                        }
-
                         /* add output decoration after computing the bounding box - the decoration extends the bounding box */
                         $(grpObj).append(getNode('path', {
                             ...clr,
-                            ...transAndPath,
+                            ...portDimensions,
+                            ...portRadius,
                             class: "input-deco",
                             "stroke-linecap": "round",
                             "stroke-linejoin": "round",
@@ -1523,9 +1527,10 @@ function renderFlow(flowId, flowdata, svgjQueryObj, renderOpts = {
                     }
 
                     /* add output decoration after computing the bounding box - the decoration extends the bounding box */
-                    $(grpObj).append(getNode('path', {
+                    $(grpObj).append(getNode('rect', {
                         ...clr,
-                        ...transAndPath,
+                        ...portDimensions,
+                        ...portRadius,
                         class: (obj.type == "link in" ? "output-deco" : ("input-deco" + (renderOpts.arrows ? " input-arrows" : ""))),
                         "stroke-linecap": "round",
                         "stroke-linejoin": "round",
@@ -1575,7 +1580,7 @@ function renderFlow(flowId, flowdata, svgjQueryObj, renderOpts = {
                         /* move the text block into the middle */
                         if ( rectHeight > txtHeight ) {
                             var offsetHeight = ( rectHeight - txtHeight) / 2;
-                            grpText.setAttributeNS(null, "transform", "translate(38," + ( (textLabels.lines.length > 1 ? 18 : 16) + offsetHeight) + ")");
+                            grpText.setAttributeNS(null, "transform", "translate(38," + ( (textLabels.lines.length > 1 ? 19 : 17) + offsetHeight) + ")");
                         }
                     }
                     
@@ -1637,27 +1642,36 @@ function renderFlow(flowId, flowdata, svgjQueryObj, renderOpts = {
 
                     /* add output decoration after computing the bounding box - the decoration extends the bounding box otherwise */
                     if ( (subflowObj.in && subflowObj.in.length > 0) || nodeIdsThatReceiveInput[obj.id] ) {
-                        $(grpObj).append(getNode('path', {
-                            ...clrByType["junction"],
-                            transform: "translate(-3,"+((obj.bbox.height/2)-5)+")",
-                            d: (renderOpts["arrows"] ? "M 0,10 9,5 0,0 Z" : "M -1,9.5 8,9.5 8,0.5 -1,0.5 Z"),
-                            class: "input-deco" + (renderOpts.arrows ? " input-arrows" : ""),
-                            "stroke-linecap": "round",
-                            "stroke-linejoin": "round",
-                        }));
+                        if (renderOpts.arrows) {
+                            $(grpObj).append(getNode('path', {
+                                ...clrByType["junction"],
+                                transform: "translate(-3,"+((obj.bbox.height/2)-5)+")",
+                                d: (renderOpts["arrows"] ? "M 0,10 9,5 0,0 Z" : "M -1,9.5 8,9.5 8,0.5 -1,0.5 Z"),
+                                class: "input-deco input-arrows",
+                                "stroke-linecap": "round",
+                                "stroke-linejoin": "round",
+                            }));
+                        } else {
+                           $(grpObj).append(getNode('rect', {
+                                ...clrByType["junction"],
+                                transform: "translate(-5,"+((obj.bbox.height/2)-5)+")",
+                                ...portDimensions,
+                                ...portRadius,
+                                class: "input-deco"
+                           }));
+                        }
                     }
 
                     var outDecoBaseAttrs = {
                         ...clrByType["junction"],
-                        d: "M 0.5,9.5 9.5,9.5 9.5,0.5 0.5,0.5 Z", // *** this is the triangle --> "M 0,10 9,5 0,0 Z",
-                        class: "output-deco",
-                        "stroke-linecap": "round",
-                        "stroke-linejoin": "round",
+                        ...portDimensions,
+                        ...portRadius,
+                        class: "output-deco"
                     };
 
                     var initFactor = (obj.wires.length == 1 ? ((obj.bbox.height / 2) - 5) : ((obj.wires.length % 2 == 0) ? 5 : 8));
                     for (var idx = 0; idx < obj.wires.length; idx++) {
-                        $(grpObj).append(getNode('path', {
+                        $(grpObj).append(getNode('rect', {
                             transform: "translate(" + (obj.bbox.width - 4) + "," + (initFactor + (13 * idx)) + ")",
                             ...outDecoBaseAttrs
                         }));
@@ -1944,5 +1958,3 @@ function renderFlow(flowId, flowdata, svgjQueryObj, renderOpts = {
     /* finally remove our changes to the objects in the flowData array */
     flowdata.forEach(function (obj) { delete obj.bbox; });
 };
- 
-     


### PR DESCRIPTION
## Commit 1
- Render the ports with `<rect>` instead of `<path>` and add rx/ry
    - This updates the `path` to a `rect` and uses `PORT_WIDTH`, `portDimensions` and a `portRadius` object to control their size.

## Commit 2
- Adds `link` and `node` classes to the respective wires/nodes, and centralizes their styling definition for default colouring and stroke.
    - Also then modifies these defaults to be more inline with the Node-RED editor